### PR TITLE
Original builder URI included in jessie.js as a comment

### DIFF
--- a/builder/app.js
+++ b/builder/app.js
@@ -87,6 +87,8 @@ app.get('/', function(req, res){
 			builderOptions.scaffolding = true;
 		}
 
+		builderOptions.returnUri = "http://" + req.headers.host + req.url.replace(/&action=Download/, "");
+
 		builder = new JessieBuilder(functionSet, constructorFnSet, requestedFunctions, requestedConstructorFns, builderOptions);
 		buildResponse = builder.build();
 

--- a/builder/libs/jessie/Builder.js
+++ b/builder/libs/jessie/Builder.js
@@ -82,6 +82,7 @@ jessie.Builder.prototype.setupHeaderDeclarations = function() {
 
 
 jessie.Builder.prototype.build = function() {
+
 	var builderResponse = {
 		success: false
 	};
@@ -108,8 +109,13 @@ jessie.Builder.prototype.build = function() {
 		var order = sortDependencies(this.functions, this.requestedFunctions);
 
 		var jsContents = '';
-		jsContents += this.header;
 
+		if(this.options.returnUri) {
+			jsContents += "\r\n/*\r\nReturn URI:\r\n" + this.options.returnUri + "\r\n*/\r\n\r\n";
+		}
+		
+		jsContents += this.header;
+		
 		/*
 
 		going to have think about this but thinking aloud:


### PR DESCRIPTION
When invoked from the web builder, the current URI of the builder is embedded at the top of the jessie.js output. As it is a comment, minification will remove it. 
