### PR TITLE
getDescendantsByClassName rendition 2 logic bug

### DIFF
--- a/functions/xhrGet/rendition1.js
+++ b/functions/xhrGet/rendition1.js
@@ -67,8 +67,7 @@ if(xhrCreate && bind && mixin) {
 		
 		xhr.open('GET', url);
 
-		var headers = {
-			'Content-Type' : 'application/x-www-form-urlencoded',
+		var headers = {			
 			'X-Requested-With' : 'XMLHttpRequest'
 		};
 		


### PR DESCRIPTION
Now honours the "el" parameter instead of always returning descendants of the document
