### PR TITLE
Fixed bug with rendition 2 of getElementParentElement, also added rendition 3

### DIFF
--- a/functions/getElementParentElement/rendition1.js
+++ b/functions/getElementParentElement/rendition1.js
@@ -12,7 +12,7 @@ Degrades:
 IE5, IE4, IE3
 */
 
-if(isHostObjectProperty( globalDocument, 'head' ) && isHostObjectProperty(globalDocument.head, 'parentNode')) {
+if(globalDocument && isHostObjectProperty( globalDocument, 'head' ) && isHostObjectProperty(globalDocument.head, 'parentNode')) {
 	getElementParentElement = function(el) {
 		var parentNode = el.parentNode,
 			parentElement = null;

--- a/functions/getElementParentElement/rendition2.js
+++ b/functions/getElementParentElement/rendition2.js
@@ -12,7 +12,7 @@ Degrades:
 IE3
 */
 
-if(isHostObjectProperty( globalDocument, 'head' ) && isHostObjectProperty(globalDocument.head, 'parentElement')) {
+if(globalDocument && isHostObjectProperty( globalDocument, 'head' ) && isHostObjectProperty(globalDocument.head, 'parentElement')) {
 	getElementParentElement = function(el) {
 		return el.parentElement;
 	};

--- a/functions/getElementParentElement/rendition3.js
+++ b/functions/getElementParentElement/rendition3.js
@@ -12,13 +12,13 @@ Degrades:
 IE3
 */
 
-if( isHostObjectProperty( globalDocument, 'head' ) && isHostObjectProperty(globalDocument.head, 'parentElement')) {
+if(globalDocument && isHostObjectProperty( globalDocument, 'head' ) && isHostObjectProperty(globalDocument.head, 'parentElement')) {
 
 	getElementParentElement = function(el) {
 		return el.parentElement;
 	};
 
-} else if( isHostObjectProperty( globalDocument, 'head' ) && isHostObjectProperty(globalDocument.head, 'parentNode')) {
+} else if(globalDocument && isHostObjectProperty( globalDocument, 'head' ) && isHostObjectProperty(globalDocument.head, 'parentNode')) {
 
 	getElementParentElement = function(el) {
 		var parentNode = el.parentNode,


### PR DESCRIPTION
Added rendition 3 and fixed the bug when using rendition 2 - html does not have a parent node. Changed to use document.head.
