### PR TITLE
"All"-checkbox (and some more), issue #87

### DIFF
--- a/builder/public/css/global.css
+++ b/builder/public/css/global.css
@@ -209,7 +209,7 @@ h1 {
 }
 
 #builder table tbody tr {
-	
+
 }
 
 #builder table tbody:nth-child(even) tr td {
@@ -243,4 +243,13 @@ h1 {
 
 .none {
 	color: #aaa;
+}
+
+#builder .methods {
+	list-style-type: none;
+	margin: .5em 0;
+}
+
+#builder input[type=checkbox][disabled] + label {
+	color: #5c5c5c;
 }

--- a/builder/public/js/ui-enhance.js
+++ b/builder/public/js/ui-enhance.js
@@ -1,0 +1,112 @@
+var uiEnhance = {
+
+  // Adds disabled-cue and "toggle all" for Constructors' prototype methods
+  "constructorMethodCheckboxes": (function () {
+    var doc = document
+      , methodsListIdPrefix = "methods-"
+      , constructorCheckboxIdPrefix = "constructor-"
+      , toggleAllCheckboxIdPrefix = "toggle-all-"
+      , constructorCheckboxGroups = {};
+
+    function countChecked(boxes) {
+      var result = 0;
+      for (var idx=0, len=boxes.length; idx<len; ++idx) {
+        if (boxes[idx].checked) {
+          result += 1;
+        }
+      }
+      return result;
+    }
+
+    function insertToggleAllBox(list, constructorName) {
+      if (!list) {return;}
+      var frag = doc.createDocumentFragment()
+        , checkbox = doc.createElement("input")
+        , label = doc.createElement("label")
+        , labelText = doc.createTextNode(" All");
+      checkbox.type = "checkbox";
+      checkbox.id = toggleAllCheckboxIdPrefix+constructorName;
+      label.setAttribute("for", checkbox.id);
+      frag.appendChild(checkbox);
+      label.appendChild(labelText);
+      frag.appendChild(label);
+      list.parentNode.insertBefore(frag, list);
+    }
+
+    // (un)?check all methods
+    function toggleMethodCheckboxes(constructorName) {
+      var checkBoxGroup = constructorCheckboxGroups[constructorName];
+      if (!checkBoxGroup) {return;}
+      for (var idx=0, len=checkBoxGroup.methods.length; idx<len; ++idx) {
+        var box = checkBoxGroup.methods[idx];
+          box.checked = checkBoxGroup.toggleMethods.checked;
+      }
+    }
+
+    // sync constructor checkbox with method (and toggleMethods) boxes
+    function syncDisabled(constructorName) {
+      var checkboxGroup = constructorCheckboxGroups[constructorName];
+      if (!checkboxGroup) {return;}
+      var boxes = checkboxGroup.methods.concat(checkboxGroup.toggleMethods);
+      for (var idx=0, len=boxes.length; idx<len; ++idx) {
+        boxes[idx].disabled = !checkboxGroup.constructor.checked;
+      }
+    }
+
+    // sync method boxes with the toggleMethods box
+    function syncToggleAll(constructorName) {
+      var checkboxGroup = constructorCheckboxGroups[constructorName];
+      if (!checkboxGroup) {return;}
+      checkboxGroup.toggleMethods.checked = countChecked(checkboxGroup.methods) == checkboxGroup.methods.length;
+    }
+
+    // get the prototype method checkboxes for a constructor
+    function getMethodCheckboxes(methodList, constructorName) {
+      var checkboxes = []
+        , inputs = methodList.getElementsByTagName("input");
+      for (var idx=0, len=inputs.length, item; idx<len; ++idx) {
+        item = inputs[idx];
+        if (item.type.toLowerCase()=="checkbox" && item.name.lastIndexOf(constructorName+"#")==0) {
+          checkboxes.push(item);
+        }
+      }
+      return checkboxes;
+    }
+
+    return function (constructorName) {
+      var methodList = doc.getElementById(methodsListIdPrefix+constructorName);
+      insertToggleAllBox(methodList, constructorName);
+      var constructorCheckboxId = constructorCheckboxIdPrefix+constructorName
+        , constructorCheckbox = doc.getElementById(constructorCheckboxId)
+        , toggleMethods = doc.getElementById(toggleAllCheckboxIdPrefix+constructorName)
+        , methodCheckboxes = getMethodCheckboxes(methodList, constructorName);
+
+      // register related checkbox elements
+      constructorCheckboxGroups[constructorName] = {
+        "constructor": constructorCheckbox
+        , "toggleMethods": toggleMethods
+        , "methods": methodCheckboxes
+      };
+
+      // toggling all methods for a constructor
+      toggleMethods.onclick = function () {
+        var toggler = this
+          , constructorName = toggler.id.replace(toggleAllCheckboxIdPrefix, "");
+        toggleMethodCheckboxes(constructorName);
+      };
+
+      // syncing the toggle-all box with the list of boxes for methods
+      methodList.onclick = function (e) {
+        var target = e.target || e.srcElement
+          , constructorName = "string" == typeof target.name && target.name.replace(/#\w+$/, "");
+        syncToggleAll(constructorName);
+      };
+
+      // (dis|en)able associated prototype methods from constructor's checkbox
+      constructorCheckbox.onclick = function () {syncDisabled(this.name);};
+      syncDisabled(constructorName); // run (dis|en)abler routine once
+    };
+
+  })()
+
+};

--- a/builder/views/index.ejs
+++ b/builder/views/index.ejs
@@ -220,8 +220,8 @@
 									<th class="code">Code</th>					
 								</tr>
 							</thead>
-						
-	
+
+
 
 						<% for(var k = 0, kl = groups.length; k < kl; k++) { %>
 						<% var currentGroup = groups[k]; %>
@@ -239,7 +239,7 @@
 							<% var currentFunction = functions[ i ]; %>
 
 								<% if(currentFunction.renditions.length) {  %>
-									
+
 										<tbody>
 											<%
 											  var anyChecked = false;
@@ -269,7 +269,7 @@
 															<% } %>
 														>
 														<label for="<%=currentFunction.name+currenntRendition.id%>" ><%=currenntRendition.id%> (Author: <%-currenntRendition.author || '<span class="none">none</span>' %>)</label>
-													
+
 													</td>
 													<td class="degrades">
 														<%- md(currenntRendition.degrades) -%>
@@ -295,7 +295,7 @@
 										</tbody>
 									<% } %>
 								<% } %>
-							
+
 							<% } %>
 						</table>
 					</div>
@@ -311,40 +311,63 @@
 							<tbody>
 								<% for(var i = 0, l = constructorFns.length; i < l; i++) { %>
 								<% var currentConstructor = constructorFns[i]; %>
+								<% var currentConstructorName = currentConstructor.name; %>
+								<% var currentConstructorCheckboxId = "constructor-"+currentConstructorName; %>
 									<tr>
 										<td>
 											<input 
 												type="checkbox" 
-												name="<%=currentConstructor.name%>" 
+												name="<%=currentConstructorName%>"
+												id="<%=currentConstructorCheckboxId%>"
 
-												<%if(query[currentConstructor.name] == 'on'){%>
+												<%if(query[currentConstructorName] == 'on'){%>
 													checked
 												<%}%>
+
 											/>
-											<label><%=currentConstructor.name%></label>											
+											<label
+												for="<%=currentConstructorCheckboxId%>"
+											><%=currentConstructorName%>
+											</label>
 										</td>
-										<td>											
+										<td>
+
+											<ul
+												class="methods"
+												id="methods-<%=currentConstructorName%>"
+											>
 											<% for(var j = 0, jl = currentConstructor.prototypeMethods.length; j < jl; j++) { %>
 											<% var currentPrototype = currentConstructor.prototypeMethods[j]; %>
-												<div class="method">
-													<input 
-														type="checkbox" 
-														name="<%=currentConstructor.name%>#<%=currentPrototype.name%>" 
+											<% var currentPrototypeCheckboxId = "currentprototype-"+currentConstructorName+"-"+currentPrototype.name.toLowerCase(); %>
+												<li>
+													<input
+														type="checkbox"
+														name="<%=currentConstructorName%>#<%=currentPrototype.name%>"
+														id="<%=currentPrototypeCheckboxId%>"
 
-														<%if(query[currentConstructor.name+'#'+currentPrototype.name] == 'on'){%>
+														<%if(query[currentConstructorName+'#'+currentPrototype.name] == 'on'){%>
 															checked
 														<%}%>
 
 													/>
-													<label><%=currentPrototype.name%></label>
-													
-												</div>
+													<label
+														for="<%=currentPrototypeCheckboxId%>"
+													><%=currentPrototype.name%></label>
+
+												</li>
 											<% } %>
+											</ul>
 										</td>
 									</tr>
 								<% } %>
 							</tbody>
 						</table>
+						<script type="text/javascript" src="js/ui-enhance.js"></script>
+						<script type="text/javascript">
+							<% for (var idx=0, len=constructorFns.length; idx<len; ++idx) { %>
+								uiEnhance.constructorMethodCheckboxes("<%=constructorFns[idx].name%>");
+							<% } %>
+						</script>
 					</div>
 					<div id="widgets">
 						<h2>Widgets</h2>


### PR DESCRIPTION
Regarding issue 87:

Use JavaScript to:
    insert a toggle-all for a constructor's prototype methods,
    sync states for the toggle-all button and the method's checkboxes
    sync disabled-state between the constructor's checkbox and the methods' checkboxes.

Display constructors' prototype methods in an unordered list instead of divs.

Give all the checkboxes in the "Constructors" section clickable labels.
