### PR TITLE
added a rendition of queryOne(selector)

### DIFF
--- a/functions/queryOne/meta.js
+++ b/functions/queryOne/meta.js
@@ -1,0 +1,4 @@
+/*
+Group:
+Element
+*/

--- a/functions/queryOne/rendition1.js
+++ b/functions/queryOne/rendition1.js
@@ -1,0 +1,19 @@
+/*global globalDocument,isHostMethod */
+
+/*
+Description:
+Relies on `document.querySelector`
+*/
+
+/*
+Author:
+Christopher Thorn
+*/
+
+var queryOne;
+
+if(globalDocument && isHostMethod(globalDocument, 'querySelector')) {
+    queryOne = function(selector, doc) {
+        return (doc || document).querySelector(selector);
+    };
+}


### PR DESCRIPTION
Uses querySelector instead of querySelectorAll.  This is more optimal than jessie.query(selector) for the use-case that only one element matching the given selector is need by the caller.  Closes #238
