### PR TITLE
Reference the window and document object directly

### DIFF
--- a/functions/deferUntilReady/rendition2.js
+++ b/functions/deferUntilReady/rendition2.js
@@ -56,7 +56,7 @@ if (isHostMethod(global, "addEventListener") && globalDocument && isHostMethod(g
 			}
 		};
 
-		global.addEventListener('load', readyListener, false);
-		globalDocument.addEventListener('DOMContentLoaded', readyListener, false);
+		window.addEventListener('load', readyListener, false);
+		document.addEventListener('DOMContentLoaded', readyListener, false);
 	};
 }


### PR DESCRIPTION
Reference the window and document object directly as the globalDocument variable is not available when the deferUntilReady method is called
