### PR TITLE
deferUntilReady:  reference the window and document objects from global

### DIFF
--- a/functions/deferUntilReady/rendition2.js
+++ b/functions/deferUntilReady/rendition2.js
@@ -56,7 +56,7 @@ if (isHostMethod(global, "addEventListener") && globalDocument && isHostMethod(g
 			}
 		};
 
-		window.addEventListener('load', readyListener, false);
-		document.addEventListener('DOMContentLoaded', readyListener, false);
+		global.window.addEventListener('load', readyListener, false);
+		global.document.addEventListener('DOMContentLoaded', readyListener, false);
 	};
 }


### PR DESCRIPTION
Reference the window and document objects from global object
