### PR TITLE
Builder tidy up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Jessie
 
-To find out more [view the wiki](https://github.com/rassie/jessie/wiki).
+To find out more [view the wiki](https://github.com/cinsoft/jessie/wiki).

--- a/README.md
+++ b/README.md
@@ -1,3 +1,25 @@
 # Jessie
 
 To find out more [view the wiki](https://github.com/cinsoft/jessie/wiki).
+
+## Getting started
+
+First install the dependencies:
+
+```bash
+npm install
+```
+
+Now you should be able to start the app:
+
+```bash
+npm run app
+```
+
+When working on the node part of the project, it's easier to have the app restart when changes to the source are made:
+
+```bash
+npm run local
+```
+
+Now when you make changes to the node source files, node will restart automatically.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Jessie Builder",
   "scripts": {
     "start": "node builder/app.js",
-    "local": "nodemon src/builder/app.js",
+    "local": "nodemon src/builder/app.js --watch src/builder",
     "dist": "npm shrinkwrap && grunt",
     "deploy": "cd dist && npm install --production; haikro build deploy --app jessie --heroku-token `heroku auth:token`",
     "runDist": "npm run dist && cd dist && npm install --production && node builder/app.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Jessie Builder",
   "scripts": {
     "start": "node builder/app.js",
-    "local": "node_modules/nodemon/bin/nodemon.js src/builder/app.js",
+    "local": "nodemon src/builder/app.js",
     "dist": "npm shrinkwrap && grunt",
     "deploy": "cd dist && npm install --production; haikro build deploy --app jessie --heroku-token `heroku auth:token`",
     "runDist": "npm run dist && cd dist && npm install --production && node builder/app.js",
@@ -22,7 +22,6 @@
     "uglify-js": "1.3.3"
   },
   "devDependencies": {
-    "cli-table": "0.2.0",
     "commander": "1.1.1",
     "grunt": "^0.4.5",
     "grunt-contrib-clean": "^0.6.0",

--- a/src/builder/app.js
+++ b/src/builder/app.js
@@ -1,12 +1,13 @@
 /*jslint node:true, strict:false*/
 
 var express = require('express');
-var app = express();
 var bodyParser = require('body-parser');
 var swig = require('swig');
 var swigExtras = require('swig-extras');
-var port = process.env.PORT || 1337;
 var path = require('path');
+
+var port = process.env.PORT || 1337;
+var app = express();
 
 app.set('views', path.resolve(__dirname, 'views'));
 

--- a/src/builder/app.js
+++ b/src/builder/app.js
@@ -1,4 +1,4 @@
-/*jslint node:true, strict:false*/
+/*jshint node:true, strict:false*/
 
 var express = require('express');
 var bodyParser = require('body-parser');

--- a/src/builder/command.js
+++ b/src/builder/command.js
@@ -3,6 +3,7 @@
 
 var program = require('commander');
 var fs = require('fs');
+var pkg = require( '../../package.json' );
 
 var JessieFunction = require('../builder/libs/jessie/Function.js');
 var JessieRendition = require('../builder/libs/jessie/Rendition.js');
@@ -27,7 +28,7 @@ var firstError;
 var message;
 
 program
-	.version('0.0.1')
+	.version( pkg.version )
 	.usage('[options] <functions ...>')
 	.option('-o, --output [file]', 'The file to output to (outputs to stdout by default)')
 	.option('-m --minify [level]', 'Minification level.')

--- a/src/builder/command.js
+++ b/src/builder/command.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/*jslint node:true, strict:false */
+/*jshint node:true, strict:false */
 
 var program = require('commander');
 var fs = require('fs');

--- a/src/builder/command.js
+++ b/src/builder/command.js
@@ -1,33 +1,30 @@
 #!/usr/bin/env node
 /*jslint node:true, strict:false */
 
-var program = require('commander'),
-	Table = require('cli-table'),
-	Set = require('simplesets').Set,
-	fs = require('fs'),
-	path = require('path'),
-	jsp = require("uglify-js").parser,
-	pro = require("uglify-js").uglify,
-	JessieFunction = require('../builder/libs/jessie/Function.js'),
-	JessieRendition = require('../builder/libs/jessie/Rendition.js'),
-	JessieConstructorFn = require('../builder/libs/jessie/ConstructorFn.js'),
-	JessiePrototypeMethod = require('../builder/libs/jessie/PrototypeMethod.js'),
-	JessieFunctionSet = require('../builder/libs/jessie/FunctionSet.js'),
-	JessieConstructorFnSet = require('../builder/libs/jessie/ConstructorFnSet.js'),
-	JessieBuilder = require('../builder/libs/jessie/Builder.js'),
-	functionSet = new JessieFunctionSet('../functions/', JessieFunction, JessieRendition),
-	constructorFnSet = new JessieConstructorFnSet('../constructors/', JessieConstructorFn, JessiePrototypeMethod),
-	requestedFunctions = [],
-	requestedConstructorFns = [],
-	buildOptions = {
+var program = require('commander');
+var fs = require('fs');
+
+var JessieFunction = require('../builder/libs/jessie/Function.js');
+var JessieRendition = require('../builder/libs/jessie/Rendition.js');
+var JessieConstructorFn = require('../builder/libs/jessie/ConstructorFn.js');
+var JessiePrototypeMethod = require('../builder/libs/jessie/PrototypeMethod.js');
+var JessieFunctionSet = require('../builder/libs/jessie/FunctionSet.js');
+var JessieConstructorFnSet = require('../builder/libs/jessie/ConstructorFnSet.js');
+var JessieBuilder = require('../builder/libs/jessie/Builder.js');
+
+var functionSet = new JessieFunctionSet('../functions/', JessieFunction, JessieRendition);
+var constructorFnSet = new JessieConstructorFnSet('../constructors/', JessieConstructorFn, JessiePrototypeMethod);
+var buildOptions = {
 		headerPath: '../libraries/header1.inc',
 		footerPath: '../libraries/footer1.inc'
-	},
-	builder = null,
-	response = null,
-	output = null,
-	firstError,
-	message;
+	};
+var requestedFunctions = [];
+var requestedConstructorFns = [];
+var builder = null;
+var response = null;
+var output = null;
+var firstError;
+var message;
 
 program
 	.version('0.0.1')

--- a/src/builder/controllers/builderController.js
+++ b/src/builder/controllers/builderController.js
@@ -1,3 +1,7 @@
+/*jshint node:true, strict: false */
+
+var path = require('path');
+
 var JessieFunction = require('../libs/jessie/Function.js');
 var JessieRendition = require('../libs/jessie/Rendition.js');
 var JessieConstructorFn = require('../libs/jessie/ConstructorFn.js');
@@ -5,15 +9,14 @@ var JessiePrototypeMethod = require('../libs/jessie/PrototypeMethod.js');
 var JessieConstructorFnSet = require('../libs/jessie/ConstructorFnSet.js');
 var JessieFunctionSet = require('../libs/jessie/FunctionSet.js');
 var JessieBuilder = require('../libs/jessie/Builder.js');
-var path = require('path');
+
+var excludedQuerystringKeys = [];
 
 var functionSet = new JessieFunctionSet(path.resolve(__dirname, '../../functions/'), JessieFunction, JessieRendition);
 var constructorFnSet = new JessieConstructorFnSet(path.resolve(__dirname, '../../constructors/'), JessieConstructorFn, JessiePrototypeMethod);
 
 functionSet.create();
 constructorFnSet.create();
-
-var excludedQuerystringKeys = [];
 
 // add constructor names to exluded keys for building up functions
 constructorFnSet.getConstructorFns().forEach(function(constructorFn) {
@@ -179,7 +182,6 @@ module.exports = function(req, res) {
 	var requestedFunctions;
 	var functions;
 	var requestedConstructorFns;
-	var namespace;
 	var minificationLevel;
 	var scaffolding = false;
 	var fileName = 'jessie';

--- a/src/builder/controllers/homeController.js
+++ b/src/builder/controllers/homeController.js
@@ -1,3 +1,4 @@
+/*jshint node:true, strict:false*/
 
 module.exports = function(req, res) {
 	res.render('index', {

--- a/src/builder/libs/jessie/Builder.js
+++ b/src/builder/libs/jessie/Builder.js
@@ -1,4 +1,4 @@
-/* jslint node:true, strict:false */
+/* jshint node:true, strict:false */
 
 var fs = require('fs');
 var uglifyParser = require("uglify-js").parser;

--- a/src/builder/libs/jessie/ConstructorFn.js
+++ b/src/builder/libs/jessie/ConstructorFn.js
@@ -1,4 +1,4 @@
-/*jslint node:true, strict:false*/
+/*jshint node:true, strict:false*/
 
 var path = require('path');
 var fs = require('fs');
@@ -27,7 +27,7 @@ function ConstructorFn(folder, PrototypeMethod) {
 			}.bind(this)
 		}
 	});
-};
+}
 
 ConstructorFn.prototype.getDependencies = function() {
 	return [];

--- a/src/builder/libs/jessie/ConstructorFnSet.js
+++ b/src/builder/libs/jessie/ConstructorFnSet.js
@@ -1,4 +1,4 @@
-/*jslint node:true, strict:false*/
+/*jshint node:true, strict:false*/
 
 var path = require('path');
 var fs = require('fs');
@@ -8,7 +8,7 @@ function ConstructorFnSet(constructorRoot, JessieConstructorFn, JessiePrototypeM
 	this.JessieConstructorFn = JessieConstructorFn;
 	this.JessiePrototypeMethod = JessiePrototypeMethod;
 	this.constructorFns = [];
-};
+}
 
 ConstructorFnSet.prototype.create = function() {
 	var fileNames = fs.readdirSync(this.constructorRoot).filter(function(fileName){

--- a/src/builder/libs/jessie/Function.js
+++ b/src/builder/libs/jessie/Function.js
@@ -1,4 +1,4 @@
-/*jslint node:true, strict:false*/
+/*jshint node:true, strict:false*/
 
 var Set = require('simplesets').Set;
 var path = require('path');

--- a/src/builder/libs/jessie/FunctionSet.js
+++ b/src/builder/libs/jessie/FunctionSet.js
@@ -1,4 +1,4 @@
-/*jslint node:true, strict:false*/
+/*jshint node:true, strict:false*/
 
 var fs = require('fs');
 var path = require('path');
@@ -13,7 +13,7 @@ function FunctionSet(functionRoot, JessieFunction, JessieRendition) {
 	this.JessieRendition = JessieRendition;
 	this.functionRoot = functionRoot;
 	this.functions = [];
-};
+}
 FunctionSet.prototype.create = function() {
 	this.functions = [];
 	// find fileNames based on directory inside root
@@ -49,8 +49,8 @@ FunctionSet.prototype.getFunctions = function() {
 FunctionSet.prototype.getFunctionsFilteredByIEVersion = function(version) {
 	this.create();
 	var fns = [],
-		fn = null,
-		renditions;
+		fn = null;
+
 	for(var i = 0; i < this.functions.length; i++) {
 		fn = this.functions[i];
 		fn.renditions = fn.getRenditionsFilteredByIEVersion(version);

--- a/src/builder/libs/jessie/PrototypeMethod.js
+++ b/src/builder/libs/jessie/PrototypeMethod.js
@@ -1,4 +1,4 @@
-/*jslint node:true, strict:false*/
+/*jshint node:true, strict:false*/
 
 var path = require('path');
 var Set = require('simplesets').Set;
@@ -34,7 +34,7 @@ function PrototypeMethod(constructorFn, file) {
 			}.bind(this)
 		}
 	});
-};
+}
 
 PrototypeMethod.prototype.getDependencies = function() {
 	return this.dependencies;

--- a/src/builder/libs/jessie/Rendition.js
+++ b/src/builder/libs/jessie/Rendition.js
@@ -1,4 +1,4 @@
-/*jslint node:true, strict:false*/
+/*jshint node:true, strict:false*/
 
 var path = require('path');
 var Set = require('simplesets').Set;


### PR DESCRIPTION
Changed nodemon call to only watch the builder files
Rely on npm env setup so we don't need the path to nodemon as it will be on $PATH
Some content in the README
Removed unused packages
Changed jslint to jshint so strict:false works
Removed some unused variables
Made style of command.js match the other files